### PR TITLE
Added synchronous method to retrieve image that does not perform network call

### DIFF
--- a/FastImageCache/FICImageCache.h
+++ b/FastImageCache/FICImageCache.h
@@ -156,6 +156,21 @@ typedef void (^FICImageRequestCompletionBlock)(UIImage *sourceImage);
 - (BOOL)asynchronouslyRetrieveImageForEntity:(id <FICEntity>)entity withFormatName:(NSString *)formatName completionBlock:(FICImageCacheCompletionBlock)completionBlock;
 
 /**
+ Returns an image from the image cache.
+ 
+ @param entity The entity that uniquely identifies the source image.
+ 
+ @param formatName The format name that uniquely identifies which image table to look in for the cached image.
+ 
+ @return The image corresponding to the given entity and formatName.
+ 
+ @note This method can return `nil` if there is no image in the cache yet and will not attempt to load it.
+ 
+ @see [FICImageCache imageExistsForEntity:withFormatName:]
+ */
+- (UIImage *)imageForEntity:(id <FICEntity>)entity withFormatName:(NSString *)formatName;
+
+/**
  Deletes an image from the image cache.
  
  @param entity The entity that uniquely identifies the source image.

--- a/FastImageCache/FICImageCache.m
+++ b/FastImageCache/FICImageCache.m
@@ -364,6 +364,18 @@ static void _FICAddCompletionBlockForEntity(NSString *formatName, NSMutableDicti
     return imageExists;
 }
 
+#pragma mark - Synchronously return Image from Cache without Network Call
+
+- (UIImage *)imageForEntity:(id <FICEntity>)entity withFormatName:(NSString *)formatName {
+    FICImageTable *imageTable = [_imageTables objectForKey:formatName];
+    NSString *entityUUID = [entity UUID];
+    NSString *sourceImageUUID = [entity sourceImageUUID];
+    
+    UIImage *image = [imageTable newImageForEntityUUID:entityUUID sourceImageUUID:sourceImageUUID preheatData:NO];
+    
+    return image;
+}
+
 #pragma mark - Invalidating Image Data
 
 - (void)deleteImageForEntity:(id <FICEntity>)entity withFormatName:(NSString *)formatName {


### PR DESCRIPTION
Related to https://github.com/path/FastImageCache/issues/35
