### PR TITLE
Optimize preheat by advising kernel to page in the data

### DIFF
--- a/FastImageCache/FICImageTableEntry.m
+++ b/FastImageCache/FICImageTableEntry.m
@@ -109,14 +109,10 @@
 }
 
 - (void)preheat {
-    int pageSize = [FICImageTable pageSize];
     void *bytes = [self bytes];
     NSUInteger length = [self length];
-    
-    // Read a byte off of each VM page to force the kernel to page in the data
-    for (NSUInteger i = 0; i < length; i += pageSize) {
-        *((volatile uint8_t *)bytes + i);
-    }
+    // Advise the kernel to page in the data
+    madvise(bytes, (size_t)length, MADV_WILLNEED);
 }
 
 @end


### PR DESCRIPTION
Using madvise to page in the data is more efficient than incurring
pagefaults by accessing one byte of each page
