### PR TITLE
Use NSJSONSerialization instead of NSPropertyListSerialization for better performance

### DIFF
--- a/FastImageCache.podspec
+++ b/FastImageCache.podspec
@@ -1,0 +1,37 @@
+Pod::Spec.new do |s|
+  s.name         = "DHPasscodeManager"
+  s.authors      = {
+                      "Mallory Paine": "mpaine@gmail.com",
+                      "Michael Potter": "michael@path.com"
+                   }
+  s.version      = "1.3"
+  s.summary      = "iOS library for quickly displaying images while scrolling"
+  s.description  = "Fast Image Cache is an efficient, persistent, and—above all—fast way to store and retrieve images in your iOS application. Part of any good iOS application's user experience is fast, smooth scrolling, and Fast Image Cache helps make this easier.\n\nA significant burden on performance for graphics-rich applications like Path is image loading. The traditional method of loading individual images from disk is just too slow, especially while scrolling. Fast Image Cache was created specifically to solve this problem.\n"
+
+  s.license      = { :type => 'MIT', :text => <<-LICENSE
+                      The MIT License (MIT)
+                      Copyright (c) 2014
+                      Permission is hereby granted, free of charge, to any person obtaining a copy
+                      of this software and associated documentation files (the "Software"), to deal
+                      in the Software without restriction, including without limitation the rights
+                      to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+                      copies of the Software, and to permit persons to whom the Software is
+                      furnished to do so, subject to the following conditions:
+                      The above copyright notice and this permission notice shall be included in
+                      all copies or substantial portions of the Software.
+                      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+                      IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+                      FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+                      AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+                      LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+                      OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+                      THE SOFTWARE.
+                      LICENSE
+                  }
+  
+  s.requires_arc = true
+
+  s.source       = { :git => "https://github.com/path/FastImageCache.git", :tag => "1.3" }
+  s.source_files = "FastImageCache"
+
+end

--- a/FastImageCache.podspec
+++ b/FastImageCache.podspec
@@ -1,9 +1,6 @@
 Pod::Spec.new do |s|
-  s.name         = "DHPasscodeManager"
-  s.authors      = {
-                      "Mallory Paine": "mpaine@gmail.com",
-                      "Michael Potter": "michael@path.com"
-                   }
+  s.name         = "FastImageCache"
+  s.author       = { "Mallory Paine" => "mpaine@gmail.com" }
   s.version      = "1.3"
   s.summary      = "iOS library for quickly displaying images while scrolling"
   s.description  = "Fast Image Cache is an efficient, persistent, and—above all—fast way to store and retrieve images in your iOS application. Part of any good iOS application's user experience is fast, smooth scrolling, and Fast Image Cache helps make this easier.\n\nA significant burden on performance for graphics-rich applications like Path is image loading. The traditional method of loading individual images from disk is just too slow, especially while scrolling. Fast Image Cache was created specifically to solve this problem.\n"

--- a/FastImageCache/FICImageTable.h
+++ b/FastImageCache/FICImageTable.h
@@ -58,11 +58,23 @@ extern NSString *const FICImageTableScreenScaleKey;
 + (int)pageSize;
 
 /**
+ Determines if the image tables are stored in the cache directory (which would mean they could disappear at any time)
+ @discussion Specifying NO will mean that the image tables will be persisted until they are reset or manually removed. Only use this setting if you're willing to use up lots of disk space.
+ Defaults to YES
+ */
++ (void)useCacheDirectory:(BOOL)useCacheDirectory;
+
+/**
+ Returns whether the image tables are being stored in the cache directory or not
+ 
+ @return BOOL indicating if image tables are stored in cache directory
+ */
++ (BOOL)usesCacheDirectory;
+
+/**
  Returns the file system path for the directory that stores image table files.
  
  @return The string representing the file system directory path where image table files are stored.
- 
- @warning Image table files are stored in the user's caches directory, so you should be prepared for the image tables to be deleted from the file system at any time.
  */
 + (NSString *)directoryPath;
 

--- a/FastImageCache/FICImageTable.m
+++ b/FastImageCache/FICImageTable.m
@@ -30,6 +30,8 @@ static NSString *const FICImageTableContextMapKey = @"contextMap";
 static NSString *const FICImageTableMRUArrayKey = @"mruArray";
 static NSString *const FICImageTableFormatKey = @"format";
 
+static NSInteger FICUseCacheDirectory = 1;
+
 #pragma mark - Class Extension
 
 @interface FICImageTable () {
@@ -106,12 +108,31 @@ static NSString *const FICImageTableFormatKey = @"format";
     return __pageSize;
 }
 
++ (void)useCacheDirectory:(BOOL)useCacheDirectory {
+    if (FICUseCacheDirectory == -1) {
+        NSLog(@"Directory path was already setup. This must be set before the path is created.");
+        return;
+    }
+    
+    FICUseCacheDirectory = useCacheDirectory;
+}
+
++ (BOOL)usesCacheDirectory {
+    return FICUseCacheDirectory;
+}
+
 + (NSString *)directoryPath {
     static NSString *__directoryPath = nil;
     
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
-        NSArray *paths = NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES);
+        NSArray *paths;
+        if (FICUseCacheDirectory == 1) {
+            paths = NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES);
+        } else {
+            paths = NSSearchPathForDirectoriesInDomains(NSLibraryDirectory, NSUserDomainMask, YES);
+        }
+        FICUseCacheDirectory = -1;
         __directoryPath = [[paths objectAtIndex:0] stringByAppendingPathComponent:@"ImageTables"];
         
         NSFileManager *fileManager = [[NSFileManager alloc] init];


### PR DESCRIPTION
Use NSJSONSerialization instead of NSPropertyListSerialization to improve the speed serializing Image Table metadata before writing to disk. This change is backward compatible with previous Image Tables