### PR TITLE
Losing precision on maximum entry count

### DIFF
--- a/FastImageCache/FICImageTable.m
+++ b/FastImageCache/FICImageTable.m
@@ -461,8 +461,8 @@ static void _FICReleaseImageData(void *info, const void *data, size_t size) {
 
 #pragma mark - Working with Entries
 
-- (int)_maximumCount {
-    return (int)MAX([_imageFormat maximumCount], _entriesPerChunk);
+- (NSInteger)_maximumCount {
+    return MAX([_imageFormat maximumCount], _entriesPerChunk);
 }
 
 - (void)_setEntryCount:(NSInteger)entryCount {


### PR DESCRIPTION
We had problems after the update to 1.3 on arm64 devices. We did set the maximum count to `NSIntegerMax` which caused _maximumCount to return -1 for the maximum size.
