### PR TITLE
Made the requirement of a non-nil formatName more explicit.

### DIFF
--- a/FastImageCache/FICImageCache.h
+++ b/FastImageCache/FICImageCache.h
@@ -122,7 +122,7 @@ typedef void (^FICImageRequestCompletionBlock)(UIImage *sourceImage);
  
  @param entity The entity that uniquely identifies the source image.
  
- @param formatName The format name that uniquely identifies which image table to look in for the cached image.
+ @param formatName The format name that uniquely identifies which image table to look in for the cached image. Must not be nil.
  
  @param completionBlock The completion block that is called when the requested image is available or if an error occurs.
  
@@ -149,7 +149,7 @@ typedef void (^FICImageRequestCompletionBlock)(UIImage *sourceImage);
  
  @param entity The entity that uniquely identifies the source image.
  
- @param formatName The format name that uniquely identifies which image table to look in for the cached image.
+ @param formatName The format name that uniquely identifies which image table to look in for the cached image. Must not be nil.
  
  @param completionBlock The completion block that is called when the requested image is available or if an error occurs.
  

--- a/FastImageCache/FICImageCache.m
+++ b/FastImageCache/FICImageCache.m
@@ -153,6 +153,8 @@ static FICImageCache *__imageCache = nil;
 }
 
 - (BOOL)_retrieveImageForEntity:(id <FICEntity>)entity withFormatName:(NSString *)formatName loadSynchronously:(BOOL)loadSynchronously completionBlock:(FICImageCacheCompletionBlock)completionBlock {
+	NSParameterAssert(formatName);
+	
     BOOL imageExists = NO;
     
     FICImageTable *imageTable = [_imageTables objectForKey:formatName];

--- a/FastImageCache/FICImageCache.m
+++ b/FastImageCache/FICImageCache.m
@@ -153,7 +153,7 @@ static FICImageCache *__imageCache = nil;
 }
 
 - (BOOL)_retrieveImageForEntity:(id <FICEntity>)entity withFormatName:(NSString *)formatName loadSynchronously:(BOOL)loadSynchronously completionBlock:(FICImageCacheCompletionBlock)completionBlock {
-	NSParameterAssert(formatName);
+    NSParameterAssert(formatName);
 	
     BOOL imageExists = NO;
     


### PR DESCRIPTION
The assertion brings the error closer to the calling code.  A `nil` `formatName` will eventually crash in `_FICAddCompletionBlockForEntity()` at `[requestDictionary setObject:formatName forKey:FICImageCacheFormatKey]`.  The assert can't go in `_FICAddCompletionBlockForEntity()` because the `NSParameterAssert` macro requires `self`.