### PR TITLE
canAccessEntryData always returned YES for NSFileProtectionCompleteUntilFirstUserAuthentication

### DIFF
--- a/FastImageCache/FICImageTable.m
+++ b/FastImageCache/FICImageTable.m
@@ -510,6 +510,7 @@ static void _FICReleaseImageData(void *info, const void *data, size_t size) {
                 _canAccessData = [NSData dataWithContentsOfMappedFile:_filePath] != nil;
             }
         }
+        result = _canAccessData
     }
     return result;
 }


### PR DESCRIPTION
Fixed bug for case when fileDataProtectionMode == NSFileProtectionCompleteUntilFirstUserAuthentication
canAccessEntryData: always returned YES in such case
