### PR TITLE
Replace use of NSData API deprecated in iOS 8

### DIFF
--- a/FastImageCache/FICImageTable.m
+++ b/FastImageCache/FICImageTable.m
@@ -687,7 +687,7 @@ static void _FICReleaseImageData(void *info, const void *data, size_t size) {
 
 - (void)_loadMetadata {
     NSString *metadataFilePath = [[_filePath stringByDeletingPathExtension] stringByAppendingPathExtension:FICImageTableMetadataFileExtension];
-    NSData *metadataData = [NSData dataWithContentsOfURL:[NSURL fileURLWithPath:metadataFilePath] options:NSDataReadingMappedAlways error:nil];
+    NSData *metadataData = [NSData dataWithContentsOfURL:[NSURL fileURLWithPath:metadataFilePath] options:NSDataReadingMappedAlways error:NULL];
     if (metadataData != nil) {
         NSDictionary *metadataDictionary = (NSDictionary *)[NSPropertyListSerialization propertyListWithData:metadataData options:0 format:NULL error:NULL];
         NSDictionary *formatDictionary = [metadataDictionary objectForKey:FICImageTableFormatKey];


### PR DESCRIPTION
`-[NSData dataWithContentsOfMappedFile:]` was deprecated in iOS 8.
`-[NSData dataWithContentsOfURL:options:error]` with
`NSDataReadingMappedIfSafe` has been around since iOS 5, so this is a
backward compatible change.

I used `NSDataReadingMappedAlways` instead of `NSDataReadingMappedIfSafe` so that the behavior is the same as the deprecated method.
