### PR TITLE
Fix UUID comparison in ImageTable to be case-insensitive.

### DIFF
--- a/FastImageCache/FICImageTable.m
+++ b/FastImageCache/FICImageTable.m
@@ -347,8 +347,8 @@ static NSString *const FICImageTableFormatKey = @"format";
         if (entryData != nil) {
             NSString *entryEntityUUID = FICStringWithUUIDBytes([entryData entityUUIDBytes]);
             NSString *entrySourceImageUUID = FICStringWithUUIDBytes([entryData sourceImageUUIDBytes]);
-            BOOL entityUUIDIsCorrect = entityUUID == nil || [entityUUID isEqualToString:entryEntityUUID];
-            BOOL sourceImageUUIDIsCorrect = sourceImageUUID == nil || [sourceImageUUID isEqualToString:entrySourceImageUUID];
+            BOOL entityUUIDIsCorrect = entityUUID == nil || [entityUUID caseInsensitiveCompare:entryEntityUUID] == NSOrderedSame;
+            BOOL sourceImageUUIDIsCorrect = sourceImageUUID == nil || [sourceImageUUID caseInsensitiveCompare:entrySourceImageUUID] == NSOrderedSame;
             
             NSNumber *indexNumber = [self _numberForEntryAtIndex:[entryData index]];
             @synchronized(indexNumber) {


### PR DESCRIPTION
If the user's image entity returns UUID in _lowercase_ this comparison will fail even if the UUID matches (since FIC UUID tends to be uppercased) leading to the entry keep getting deleted (line 357 executed) and no image being returned to the user or cached.