### PR TITLE
Namespaces implementation

### DIFF
--- a/FastImageCache/FICImageCache.h
+++ b/FastImageCache/FICImageCache.h
@@ -24,6 +24,14 @@ typedef void (^FICImageRequestCompletionBlock)(UIImage *sourceImage);
  */
 @interface FICImageCache : NSObject
 
+/**
+ The namespace of the image cache.
+ 
+ @discussion Namespace is responsible for isolation of dirrerent image cache instances on file system level. Namespace should be unique across application.
+ */
+
+@property (readonly, nonatomic) NSString *nameSpace;
+
 ///----------------------------
 /// @name Managing the Delegate
 ///----------------------------
@@ -37,6 +45,25 @@ typedef void (^FICImageRequestCompletionBlock)(UIImage *sourceImage);
 @property (nonatomic, weak) id <FICImageCacheDelegate> delegate;
 
 ///---------------------------------------
+/// @name Creating Image Cache instances
+///---------------------------------------
+
+/**
+ Returns new image cache.
+ 
+ @return A new instance of `FICImageCache`.
+ 
+ @param nameSpace The namespace that uniquely identifies current image cahce entity. If no nameSpace given, default namespace will be used.
+ 
+ @note Fast Image Cache can either be used as a singleton for convenience or can exist as multiple instances. 
+ However, all instances of `FICImageCache` will make use same dispatch queue. To separate location on disk for storing image tables namespaces are used.
+ 
+ @see [FICImageCache dispatchQueue]
+ */
+
+- (instancetype) initWithNameSpace:(NSString *)nameSpace;
+
+///---------------------------------------
 /// @name Accessing the Shared Image Cache
 ///---------------------------------------
 
@@ -45,8 +72,7 @@ typedef void (^FICImageRequestCompletionBlock)(UIImage *sourceImage);
  
  @return A shared instance of `FICImageCache`.
  
- @note Fast Image Cache can either be used as a singleton for convenience or can exist as multiple instances. However, all instances of `FICImageCache` will make use of
- shared resources, such as the same dispatch queue and the same location on disk for storing image tables.
+ @note Shared instance always binded to default namespace.
  
  @see [FICImageCache dispatchQueue]
  */

--- a/FastImageCache/FICImageCache.m
+++ b/FastImageCache/FICImageCache.m
@@ -79,12 +79,16 @@ static FICImageCache *__imageCache = nil;
 }
 
 - (id)init {
+    return [self initWithNameSpace:@"FICDefaultNamespace"];
+}
+
+- (instancetype)initWithNameSpace:(NSString *)nameSpace {
     self = [super init];
-    
-    if (self != nil) {
+    if (self) {
         _formats = [[NSMutableDictionary alloc] init];
         _imageTables = [[NSMutableDictionary alloc] init];
         _requests = [[NSMutableDictionary alloc] init];
+        _nameSpace = nameSpace;
     }
     return self;
 }
@@ -114,6 +118,9 @@ static FICImageCache *__imageCache = nil;
         // Remove any extraneous files in the image tables directory
         NSFileManager *fileManager = [NSFileManager defaultManager];
         NSString *directoryPath = [FICImageTable directoryPath];
+        if (self.nameSpace) {
+            directoryPath = [directoryPath stringByAppendingPathComponent:self.nameSpace];
+        }
         NSArray *fileNames = [fileManager contentsOfDirectoryAtPath:directoryPath error:nil];
         for (NSString *fileName in fileNames) {
             if ([imageTableFiles containsObject:fileName] == NO) {


### PR DESCRIPTION
There was problem in case of several cache instances in the app.
All cache instances was forced to use same formats because tables, that not presented in formats list, was deleted by setFormats.

I decided to solve this problem with namespaces. Now instances with different namespace will not affect on each other. Changes are backward compatible with current FastImageCache.