### PR TITLE
Added unique identifiers for caches

### DIFF
--- a/FastImageCache/FICImageCache.h
+++ b/FastImageCache/FICImageCache.h
@@ -46,11 +46,31 @@ typedef void (^FICImageRequestCompletionBlock)(UIImage *sourceImage);
  @return A shared instance of `FICImageCache`.
  
  @note Fast Image Cache can either be used as a singleton for convenience or can exist as multiple instances. However, all instances of `FICImageCache` will make use of
- shared resources, such as the same dispatch queue and the same location on disk for storing image tables.
+ shared resources, such as the same dispatch queue. However, different instances with unique identifiers will store their files in unique location on disk. It is important
+ that each instance of `FICImageCache` have a unique identifier that persists between launches. Creating multiple instances with the same identifier will cause conflicts.
  
  @see [FICImageCache dispatchQueue]
  */
 + (instancetype)sharedImageCache;
+
+/**
+ Returns an image cache isolated by the identifier.
+ 
+ @return A new instance of `FICImageCache`.
+ 
+ @note Fast Image Cache can either be used as a singleton for convenience or can exist as multiple instances. However, all instances of `FICImageCache` will make use of
+ shared resources, such as the same dispatch queue. However, different instances with unique identifiers will store their files in unique location on disk. It is important
+ that each instance of `FICImageCache` have a unique identifier that persists between launches. Creating multiple instances with the same identifier will cause conflicts.
+ 
+ @see [FICImageCache dispatchQueue]
+ */
+- (instancetype)initWithIdentifier:(NSString *)identifier NS_DESIGNATED_INITIALIZER;
+
+/** The image cache's unique identifier
+ 
+ This identifier is used to uniquely identify each cache between launches. This is nil for the sharedImageCache, which causes the cache to fall back to 1.3 behavior.
+ */
+@property (copy, readonly) NSString *identifier;
 
 /**
  Returns the shared dispatch queue used by all instances of `FICImageCache`.

--- a/FastImageCache/FICImageCache.m
+++ b/FastImageCache/FICImageCache.m
@@ -79,9 +79,14 @@ static FICImageCache *__imageCache = nil;
 }
 
 - (id)init {
+    return [self initWithIdentifier:nil];
+}
+
+- (instancetype)initWithIdentifier:(NSString *)identifier {
     self = [super init];
     
     if (self != nil) {
+        _identifier = [identifier copy];
         _formats = [[NSMutableDictionary alloc] init];
         _imageTables = [[NSMutableDictionary alloc] init];
         _requests = [[NSMutableDictionary alloc] init];
@@ -113,7 +118,7 @@ static FICImageCache *__imageCache = nil;
         
         // Remove any extraneous files in the image tables directory
         NSFileManager *fileManager = [NSFileManager defaultManager];
-        NSString *directoryPath = [FICImageTable directoryPath];
+        NSString *directoryPath = [FICImageTable directoryPathForIdentifier:self.identifier];
         NSArray *fileNames = [fileManager contentsOfDirectoryAtPath:directoryPath error:nil];
         for (NSString *fileName in fileNames) {
             if ([imageTableFiles containsObject:fileName] == NO) {

--- a/FastImageCache/FICImageTable.h
+++ b/FastImageCache/FICImageTable.h
@@ -58,13 +58,31 @@ extern NSString *const FICImageTableScreenScaleKey;
 + (int)pageSize;
 
 /**
+ Returns the file system path for the directory that stores image table files. This returns the shared cache's directory.
+ 
+ @return The string representing the file system directory path where image table files are stored.
+ 
+ @warning Image table files are stored in the user's caches directory, so you should be prepared for the image tables to be deleted from the file system at any time.
+ */
++ (NSString *)directoryPath DEPRECATED_ATTRIBUTE;
+
+/**
  Returns the file system path for the directory that stores image table files.
  
  @return The string representing the file system directory path where image table files are stored.
  
  @warning Image table files are stored in the user's caches directory, so you should be prepared for the image tables to be deleted from the file system at any time.
  */
-+ (NSString *)directoryPath;
++ (NSString *)directoryPathForIdentifier:(NSString *)identifier;
+
+/**
+ Returns the file system path for the directory that stores image table files. This calls `-directoryPathForIdentifier:` with the table's cache's identifier.
+ 
+ @return The string representing the file system directory path where image table files are stored.
+ 
+ @warning Image table files are stored in the user's caches directory, so you should be prepared for the image tables to be deleted from the file system at any time.
+ */
+- (NSString *)directoryPath;
 
 ///----------------------------------
 /// @name Initializing an Image Table

--- a/FastImageCacheDemo/Classes/FICDAppDelegate.m
+++ b/FastImageCacheDemo/Classes/FICDAppDelegate.m
@@ -70,12 +70,26 @@
     [sharedImageCache setDelegate:self];
     [sharedImageCache setFormats:mutableImageFormats];
     
+    FICImageCache *customImageCache = [[FICImageCache alloc] initWithIdentifier:@"Custom"];
+    [customImageCache setDelegate:self];
+    [customImageCache setFormats:@[
+                                   [FICImageFormat formatWithName:FICDPhotoSquareImage32BitBGRACustomFormatName family:FICDPhotoImageFormatFamily imageSize:FICDPhotoSquareImageSize style:FICImageFormatStyle32BitBGRA
+                                                     maximumCount:squareImageFormatMaximumCount devices:squareImageFormatDevices protectionMode:FICImageFormatProtectionModeNone],
+                                   [FICImageFormat formatWithName:FICDPhotoSquareImage32BitBGRCustomFormatName family:FICDPhotoImageFormatFamily imageSize:FICDPhotoSquareImageSize style:FICImageFormatStyle32BitBGR
+                                                     maximumCount:squareImageFormatMaximumCount devices:squareImageFormatDevices protectionMode:FICImageFormatProtectionModeNone],
+                                   [FICImageFormat formatWithName:FICDPhotoSquareImage16BitBGRCustomFormatName family:FICDPhotoImageFormatFamily imageSize:FICDPhotoSquareImageSize style:FICImageFormatStyle16BitBGR
+                                                     maximumCount:squareImageFormatMaximumCount devices:squareImageFormatDevices protectionMode:FICImageFormatProtectionModeNone],
+                                   [FICImageFormat formatWithName:FICDPhotoSquareImage8BitGrayscaleCustomFormatName family:FICDPhotoImageFormatFamily imageSize:FICDPhotoSquareImageSize style:FICImageFormatStyle8BitGrayscale
+                                                     maximumCount:squareImageFormatMaximumCount devices:squareImageFormatDevices protectionMode:FICImageFormatProtectionModeNone],
+                                   ]];
+    
     // Configure the window
     CGRect windowFrame = [[UIScreen mainScreen] bounds];
     UIWindow *window = [[UIWindow alloc] initWithFrame:windowFrame];
     [self setWindow:window];
     
-    UIViewController *rootViewController = [[FICDViewController alloc] init];
+    FICDViewController *rootViewController = [[FICDViewController alloc] init];
+    rootViewController.customImageCache = customImageCache;
     UINavigationController *navigationController = [[UINavigationController alloc] initWithRootViewController:rootViewController];
     
     [[self window] setRootViewController:navigationController];

--- a/FastImageCacheDemo/Classes/FICDPhoto.h
+++ b/FastImageCacheDemo/Classes/FICDPhoto.h
@@ -14,6 +14,12 @@ extern NSString *const FICDPhotoSquareImage32BitBGRAFormatName;
 extern NSString *const FICDPhotoSquareImage32BitBGRFormatName;
 extern NSString *const FICDPhotoSquareImage16BitBGRFormatName;
 extern NSString *const FICDPhotoSquareImage8BitGrayscaleFormatName;
+
+extern NSString *const FICDPhotoSquareImage32BitBGRACustomFormatName;
+extern NSString *const FICDPhotoSquareImage32BitBGRCustomFormatName;
+extern NSString *const FICDPhotoSquareImage16BitBGRCustomFormatName;
+extern NSString *const FICDPhotoSquareImage8BitGrayscaleCustomFormatName;
+
 extern NSString *const FICDPhotoPixelImageFormatName;
 
 extern CGSize const FICDPhotoSquareImageSize;

--- a/FastImageCacheDemo/Classes/FICDPhoto.m
+++ b/FastImageCacheDemo/Classes/FICDPhoto.m
@@ -17,6 +17,12 @@ NSString *const FICDPhotoSquareImage32BitBGRAFormatName = @"com.path.FastImageCa
 NSString *const FICDPhotoSquareImage32BitBGRFormatName = @"com.path.FastImageCacheDemo.FICDPhotoSquareImage32BitBGRFormatName";
 NSString *const FICDPhotoSquareImage16BitBGRFormatName = @"com.path.FastImageCacheDemo.FICDPhotoSquareImage16BitBGRFormatName";
 NSString *const FICDPhotoSquareImage8BitGrayscaleFormatName = @"com.path.FastImageCacheDemo.FICDPhotoSquareImage8BitGrayscaleFormatName";
+
+NSString *const FICDPhotoSquareImage32BitBGRACustomFormatName = @"com.path.FastImageCacheDemo.FICDPhotoSquareImage32BitBGRAFormatName.custom";
+NSString *const FICDPhotoSquareImage32BitBGRCustomFormatName = @"com.path.FastImageCacheDemo.FICDPhotoSquareImage32BitBGRFormatName.custom";
+NSString *const FICDPhotoSquareImage16BitBGRCustomFormatName = @"com.path.FastImageCacheDemo.FICDPhotoSquareImage16BitBGRFormatName.custom";
+NSString *const FICDPhotoSquareImage8BitGrayscaleCustomFormatName = @"com.path.FastImageCacheDemo.FICDPhotoSquareImage8BitGrayscaleFormatName.custom";
+
 NSString *const FICDPhotoPixelImageFormatName = @"com.path.FastImageCacheDemo.FICDPhotoPixelImageFormatName";
 
 CGSize const FICDPhotoSquareImageSize = {75, 75};
@@ -200,7 +206,7 @@ static UIImage * _FICDStatusBarImageFromImage(UIImage *image) {
             [statusBarImage drawInRect:contextBounds];
             UIGraphicsPopContext();
         } else {
-            if ([formatName isEqualToString:FICDPhotoSquareImage32BitBGRAFormatName] == NO) {
+            if (![formatName isEqualToString:FICDPhotoSquareImage32BitBGRAFormatName] && ![formatName isEqualToString:FICDPhotoSquareImage32BitBGRACustomFormatName]) {
                 // Fill with white for image formats that are opaque
                 CGContextSetFillColorWithColor(contextRef, [[UIColor whiteColor] CGColor]);
                 CGContextFillRect(contextRef, contextBounds);
@@ -209,7 +215,12 @@ static UIImage * _FICDStatusBarImageFromImage(UIImage *image) {
             UIImage *squareImage = _FICDSquareImageFromImage(image);
             
             // Clip to a rounded rect
-            CGPathRef path = _FICDCreateRoundedRectPath(contextBounds, 12);
+            CGPathRef path;
+            if ([[formatName componentsSeparatedByString:@"."] containsObject:@"custom"]) {
+                path = _FICDCreateRoundedRectPath(contextBounds, contextSize.width / 2.0);
+            } else {
+                path = _FICDCreateRoundedRectPath(contextBounds, 12);
+            }
             CGContextAddPath(contextRef, path);
             CFRelease(path);
             CGContextEOClip(contextRef);

--- a/FastImageCacheDemo/Classes/FICDPhotosTableViewCell.h
+++ b/FastImageCacheDemo/Classes/FICDPhotosTableViewCell.h
@@ -7,6 +7,7 @@
 //
 
 @class FICDPhoto;
+@class FICImageCache;
 
 @protocol FICDPhotosTableViewCellDelegate;
 
@@ -16,6 +17,7 @@
 @property (nonatomic, assign) BOOL usesImageTable;
 @property (nonatomic, copy) NSArray *photos;
 @property (nonatomic, copy) NSString *imageFormatName;
+@property (nonatomic, strong) FICImageCache *imageCache;
 
 + (NSString *)reuseIdentifier;
 + (NSInteger)photosPerRow;

--- a/FastImageCacheDemo/Classes/FICDPhotosTableViewCell.m
+++ b/FastImageCacheDemo/Classes/FICDPhotosTableViewCell.m
@@ -63,7 +63,7 @@
             UIImageView *imageView = [_imageViews objectAtIndex:i];
             
             if (_usesImageTable) {
-                [[FICImageCache sharedImageCache] retrieveImageForEntity:photo withFormatName:_imageFormatName completionBlock:^(id<FICEntity> entity, NSString *formatName, UIImage *image) {
+                [self.imageCache retrieveImageForEntity:photo withFormatName:_imageFormatName completionBlock:^(id<FICEntity> entity, NSString *formatName, UIImage *image) {
                     // This completion block may be called much later. We should check to make sure this cell hasn't been reused for different photos before displaying the image that has loaded.
                     if (photos == [self photos]) {
                         [imageView setImage:image];

--- a/FastImageCacheDemo/Classes/FICDViewController.h
+++ b/FastImageCacheDemo/Classes/FICDViewController.h
@@ -7,7 +7,10 @@
 //
 
 @class FICDTableView;
+@class FICImageCache;
 
 @interface FICDViewController : UIViewController
+
+@property (nonatomic, strong) FICImageCache *customImageCache;
 
 @end


### PR DESCRIPTION
Now caches can be isolated by identifier so that individual instances can be created that don't colide with each other. This is important in order to make libraries able to use FastImageCache without conflicting with other libraries or the host application's use of FIC.

We could go one step further and give each instance it's own dispatch_queue, but since that was not necessary to make isolated queues work, I left that for another day.