### PR TITLE
Make file protection availability check more robust

### DIFF
--- a/FastImageCache/FastImageCache/FastImageCache/FICImageTable.m
+++ b/FastImageCache/FastImageCache/FastImageCache/FICImageTable.m
@@ -513,23 +513,23 @@ static void _FICReleaseImageData(void *info, const void *data, size_t size) {
 // accessible and when you try to use that data. Sidestep this issue altogether
 // by using NSFileProtectionNone
 - (BOOL)canAccessEntryData {
-    BOOL result = YES;
-    if ([_fileDataProtectionMode isEqualToString:NSFileProtectionComplete]) {
-        result = [[UIApplication sharedApplication] isProtectedDataAvailable];
-    } else if ([_fileDataProtectionMode isEqualToString:NSFileProtectionCompleteUntilFirstUserAuthentication]) {
-        // For "complete until first auth", if we were previously able to access data, then we'll still be able to
-        // access it. If we haven't yet been able to access data, we'll need to try until we are successful.
-        if (_canAccessData == NO) {
-            if ([[UIApplication sharedApplication] isProtectedDataAvailable]) {
-                // we are unlocked, so we're good to go.
-                _canAccessData = YES;
-            } else {
-                // we are locked, so try to access data.
-                _canAccessData = [NSData dataWithContentsOfURL:[NSURL fileURLWithPath:_filePath] options:NSDataReadingMappedAlways error:NULL] != nil;
-            }
-        }
+    if ([_fileDataProtectionMode isEqualToString:NSFileProtectionNone])
+        return YES;
+    
+    if ([_fileDataProtectionMode isEqualToString:NSFileProtectionCompleteUntilFirstUserAuthentication] && _canAccessData)
+        return YES;
+    
+    UIApplication *application = [UIApplication performSelector:@selector(sharedApplication)];
+    if (application) {
+        _canAccessData = [application isProtectedDataAvailable];
+    } else {
+        int fd;
+        _canAccessData = ((fd = open([_filePath fileSystemRepresentation], O_RDONLY)) != -1);
+        if (_canAccessData)
+            close(fd);
     }
-    return result;
+    
+    return _canAccessData;
 }
 
 - (FICImageTableEntry *)_entryDataAtIndex:(NSInteger)index {


### PR DESCRIPTION
When the file is unavailable, any attempt to `open` it will fail with `EPERM`. The previous fallback `NSData` check worked, but also tried to map the file into memory.

It's interesting to note that the previous check always returned `YES` for `NSFileProtectionCompleteUntilFirstUserAuthentication`, because `result`, the return value, is never modified.

One important advantage of this check over the previous one is that it works accurately from an extension, where there is no `UIApplication`.

Fixes #91 