### PR TITLE
Thread safety fixes

### DIFF
--- a/FastImageCache/FastImageCache/FastImageCache/FICImageCache.m
+++ b/FastImageCache/FastImageCache/FastImageCache/FICImageCache.m
@@ -54,18 +54,15 @@ static NSString *const FICImageCacheEntityKey = @"FICImageCacheEntityKey";
     }
 }
 
-static FICImageCache *__imageCache = nil;
-
 #pragma mark - Object Lifecycle
 
 + (instancetype)sharedImageCache {
-    if (__imageCache == nil) {
-        static dispatch_once_t onceToken;
-        dispatch_once(&onceToken, ^{
-            __imageCache = [[[self class] alloc] init];
-        });
-    }
-    
+    static dispatch_once_t onceToken;
+    static FICImageCache *__imageCache = nil;
+    dispatch_once(&onceToken, ^{
+        __imageCache = [[[self class] alloc] init];
+    });
+
     return __imageCache;
 }
 

--- a/FastImageCache/FastImageCache/FastImageCache/FICImageCache.m
+++ b/FastImageCache/FastImageCache/FastImageCache/FICImageCache.m
@@ -25,7 +25,6 @@ static NSString *const FICImageCacheEntityKey = @"FICImageCacheEntityKey";
     NSMutableDictionary *_formats;
     NSMutableDictionary *_imageTables;
     NSMutableDictionary *_requests;
-    __weak id <FICImageCacheDelegate> _delegate;
     
     BOOL _delegateImplementsWantsSourceImageForEntityWithFormatNameCompletionBlock;
     BOOL _delegateImplementsShouldProcessAllFormatsInFamilyForEntity;


### PR DESCRIPTION
- Remove double-checked lock, just use `dispatch_once`.
The latter does more expected optimization stuff than a simple `if` check, and also avoids potential race conditions (the instance may be assigned but not finished initializing yet).

- Safely access `_requests` dictionary across threads.
This dictionary (and its mutable values) are mutated from multiple threads; ensure these changes are synchronized.