### PR TITLE
Ignore Carthage folder & minor Umbrella header fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ DerivedData
 
 # Demo Images
 FastImageCacheDemo/Demo Images/*.jpg
+Carthage

--- a/FastImageCache/FastImageCache.xcodeproj/project.pbxproj
+++ b/FastImageCache/FastImageCache.xcodeproj/project.pbxproj
@@ -23,7 +23,7 @@
 		B2E5679E1B316D9600906840 /* FICImageTableEntry.h in Headers */ = {isa = PBXBuildFile; fileRef = B2E5678F1B316D9600906840 /* FICImageTableEntry.h */; };
 		B2E5679F1B316D9600906840 /* FICImageTableEntry.m in Sources */ = {isa = PBXBuildFile; fileRef = B2E567901B316D9600906840 /* FICImageTableEntry.m */; };
 		B2E567A01B316D9600906840 /* FICImports.h in Headers */ = {isa = PBXBuildFile; fileRef = B2E567911B316D9600906840 /* FICImports.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		B2E567A11B316D9600906840 /* FICUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = B2E567921B316D9600906840 /* FICUtilities.h */; };
+		B2E567A11B316D9600906840 /* FICUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = B2E567921B316D9600906840 /* FICUtilities.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B2E567A21B316D9600906840 /* FICUtilities.m in Sources */ = {isa = PBXBuildFile; fileRef = B2E567931B316D9600906840 /* FICUtilities.m */; };
 		B2E567AC1B316DCA00906840 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = B2E567AB1B316DCA00906840 /* main.m */; };
 		B2E567DA1B316E1000906840 /* FICDAppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = B2E567CF1B316E1000906840 /* FICDAppDelegate.m */; };
@@ -252,8 +252,8 @@
 				B2E567941B316D9600906840 /* FICEntity.h in Headers */,
 				B2E567A01B316D9600906840 /* FICImports.h in Headers */,
 				B2E567981B316D9600906840 /* FICImageFormat.h in Headers */,
-				B2E5679C1B316D9600906840 /* FICImageTableChunk.h in Headers */,
 				B2E567A11B316D9600906840 /* FICUtilities.h in Headers */,
+				B2E5679C1B316D9600906840 /* FICImageTableChunk.h in Headers */,
 				B2E567951B316D9600906840 /* FICImageCache+FICErrorLogging.h in Headers */,
 				B2E567961B316D9600906840 /* FICImageCache.h in Headers */,
 				B2E5676E1B316D5800906840 /* FastImageCache.h in Headers */,

--- a/FastImageCache/FastImageCache.xcodeproj/project.pbxproj
+++ b/FastImageCache/FastImageCache.xcodeproj/project.pbxproj
@@ -14,7 +14,7 @@
 		B2E567951B316D9600906840 /* FICImageCache+FICErrorLogging.h in Headers */ = {isa = PBXBuildFile; fileRef = B2E567861B316D9600906840 /* FICImageCache+FICErrorLogging.h */; };
 		B2E567961B316D9600906840 /* FICImageCache.h in Headers */ = {isa = PBXBuildFile; fileRef = B2E567871B316D9600906840 /* FICImageCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B2E567971B316D9600906840 /* FICImageCache.m in Sources */ = {isa = PBXBuildFile; fileRef = B2E567881B316D9600906840 /* FICImageCache.m */; };
-		B2E567981B316D9600906840 /* FICImageFormat.h in Headers */ = {isa = PBXBuildFile; fileRef = B2E567891B316D9600906840 /* FICImageFormat.h */; };
+		B2E567981B316D9600906840 /* FICImageFormat.h in Headers */ = {isa = PBXBuildFile; fileRef = B2E567891B316D9600906840 /* FICImageFormat.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B2E567991B316D9600906840 /* FICImageFormat.m in Sources */ = {isa = PBXBuildFile; fileRef = B2E5678A1B316D9600906840 /* FICImageFormat.m */; };
 		B2E5679A1B316D9600906840 /* FICImageTable.h in Headers */ = {isa = PBXBuildFile; fileRef = B2E5678B1B316D9600906840 /* FICImageTable.h */; };
 		B2E5679B1B316D9600906840 /* FICImageTable.m in Sources */ = {isa = PBXBuildFile; fileRef = B2E5678C1B316D9600906840 /* FICImageTable.m */; };
@@ -22,7 +22,7 @@
 		B2E5679D1B316D9600906840 /* FICImageTableChunk.m in Sources */ = {isa = PBXBuildFile; fileRef = B2E5678E1B316D9600906840 /* FICImageTableChunk.m */; };
 		B2E5679E1B316D9600906840 /* FICImageTableEntry.h in Headers */ = {isa = PBXBuildFile; fileRef = B2E5678F1B316D9600906840 /* FICImageTableEntry.h */; };
 		B2E5679F1B316D9600906840 /* FICImageTableEntry.m in Sources */ = {isa = PBXBuildFile; fileRef = B2E567901B316D9600906840 /* FICImageTableEntry.m */; };
-		B2E567A01B316D9600906840 /* FICImports.h in Headers */ = {isa = PBXBuildFile; fileRef = B2E567911B316D9600906840 /* FICImports.h */; };
+		B2E567A01B316D9600906840 /* FICImports.h in Headers */ = {isa = PBXBuildFile; fileRef = B2E567911B316D9600906840 /* FICImports.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B2E567A11B316D9600906840 /* FICUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = B2E567921B316D9600906840 /* FICUtilities.h */; };
 		B2E567A21B316D9600906840 /* FICUtilities.m in Sources */ = {isa = PBXBuildFile; fileRef = B2E567931B316D9600906840 /* FICUtilities.m */; };
 		B2E567AC1B316DCA00906840 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = B2E567AB1B316DCA00906840 /* main.m */; };
@@ -250,9 +250,9 @@
 				B2E5679A1B316D9600906840 /* FICImageTable.h in Headers */,
 				B2E5679E1B316D9600906840 /* FICImageTableEntry.h in Headers */,
 				B2E567941B316D9600906840 /* FICEntity.h in Headers */,
+				B2E567A01B316D9600906840 /* FICImports.h in Headers */,
 				B2E567981B316D9600906840 /* FICImageFormat.h in Headers */,
 				B2E5679C1B316D9600906840 /* FICImageTableChunk.h in Headers */,
-				B2E567A01B316D9600906840 /* FICImports.h in Headers */,
 				B2E567A11B316D9600906840 /* FICUtilities.h in Headers */,
 				B2E567951B316D9600906840 /* FICImageCache+FICErrorLogging.h in Headers */,
 				B2E567961B316D9600906840 /* FICImageCache.h in Headers */,

--- a/FastImageCache/FastImageCache/FastImageCache.h
+++ b/FastImageCache/FastImageCache/FastImageCache.h
@@ -16,3 +16,4 @@ FOUNDATION_EXPORT const unsigned char FastImageCacheVersionString[];
 
 #import <FastImageCache/FICImageCache.h>
 #import <FastImageCache/FICEntity.h>
+#import <FastImageCache/FICUtilities.h>


### PR DESCRIPTION
+ Added the Carthage folder to `.gitignore`
+ Included the following headers/made them public
    - `FICUtilities.h`
    - `FICImageFormat.h`
    - `FICImports.h`