### PR TITLE
Preventing possible infinite loop

### DIFF
--- a/FastImageCache/FastImageCache/FastImageCache/FICImageTable.m
+++ b/FastImageCache/FastImageCache/FastImageCache/FICImageTable.m
@@ -432,15 +432,16 @@ static void _FICReleaseImageData(void *info, const void *data, size_t size) {
     if (entityUUID != nil) {
         [_lock lock];
         
+        NSInteger MRUIndex = [_MRUEntries indexOfObject:entityUUID];
+        if (MRUIndex != NSNotFound) {
+            [_MRUEntries removeObjectAtIndex:MRUIndex];
+        }
+        
         NSInteger index = [self _indexOfEntryForEntityUUID:entityUUID];
         if (index != NSNotFound) {
             [_sourceImageMap removeObjectForKey:entityUUID];
             [_indexMap removeObjectForKey:entityUUID];
             [_occupiedIndexes removeIndex:index];
-            NSInteger index = [_MRUEntries indexOfObject:entityUUID];
-            if (index != NSNotFound) {
-                [_MRUEntries removeObjectAtIndex:index];
-            }
             [self saveMetadata];
         }
         


### PR DESCRIPTION
We have a crash in our app in an infinite loop in `[FCImageTable _nextEntryIndex]`: http://crashes.to/s/1b2a185cb18

The issue seems to be that when going through the process of deleting entries when the cache becomes too large, you are getting entries from the _MRUEntries but then relying on the index to also exist in the main tables. If `[self _indexOfEntryForEntityUUID:entityUUID]` does not find an index, you also do not remove that entry from the MRUEntries, and when `_nextEntryIndex` calls itself, it will again find that entry in the _MRUEntries and do the process again and so on forever.

My proposed fix is to always remove the entry from the _MRUEntries object as long as it exists in there, to prevent this infinite loop.