### PR TITLE
add prefix `fic` to all the property and method in protocol `FICEntity`.

### DIFF
--- a/FastImageCache/FastImageCache/FastImageCache/FICEntity.h
+++ b/FastImageCache/FastImageCache/FastImageCache/FICEntity.h
@@ -24,7 +24,7 @@ typedef void (^FICEntityImageDrawingBlock)(CGContextRef context, CGSize contextS
  @discussion Within each image table, each entry is identified by an entity's UUID. Ideally, this value should never change for an entity. For example, if your entity class is a person
  model, its UUID might be an API-assigned, unchanging, unique user ID. No matter how the properties of the person change, its user ID should never change.
  */
-@property (nonatomic, copy, readonly) NSString *FIC_UUID;
+@property (nonatomic, copy, readonly) NSString *fic_UUID;
 
 /**
  A string that uniquely identifies an entity's source image.
@@ -32,7 +32,7 @@ typedef void (^FICEntityImageDrawingBlock)(CGContextRef context, CGSize contextS
  @discussion While `<UUID>` should be unchanging, a source image UUID might change. For example, if your entity class is a person model, its source image UUID might change every time the
  person changes their profile photo. In this case, the source image UUID might be a hash of the profile photo URL (assuming each image is given a unique URL).
  */
-@property (nonatomic, copy, readonly) NSString *FIC_sourceImageUUID;
+@property (nonatomic, copy, readonly) NSString *fic_sourceImageUUID;
 
 /**
  Returns the source image URL associated with a specific format name.
@@ -52,7 +52,7 @@ typedef void (^FICEntityImageDrawingBlock)(CGContextRef context, CGSize contextS
  @see FICImageFormat
  @see [FICImageCacheDelegate imageCache:wantsSourceImageForEntity:withFormatName:completionBlock:]
  */
-- (NSURL *)FIC_sourceImageURLWithFormatName:(NSString *)formatName;
+- (NSURL *)fic_sourceImageURLWithFormatName:(NSString *)formatName;
 
 /**
  Returns the drawing block for a specific image and format name.
@@ -73,7 +73,7 @@ typedef void (^FICEntityImageDrawingBlock)(CGContextRef context, CGSize contextS
  
  @note This block will always be called from the serial dispatch queue used by the image cache.
  */
-- (FICEntityImageDrawingBlock)FIC_drawingBlockForImage:(UIImage *)image withFormatName:(NSString *)formatName;
+- (FICEntityImageDrawingBlock)fic_drawingBlockForImage:(UIImage *)image withFormatName:(NSString *)formatName;
 
 @optional
 /**
@@ -81,6 +81,6 @@ typedef void (^FICEntityImageDrawingBlock)(CGContextRef context, CGSize contextS
  
  @param format The image format that identifies which image table is requesting the source image.
  */
-- (UIImage *)FIC_imageForFormat:(FICImageFormat *)format;
+- (UIImage *)fic_imageForFormat:(FICImageFormat *)format;
 
 @end

--- a/FastImageCache/FastImageCache/FastImageCache/FICEntity.h
+++ b/FastImageCache/FastImageCache/FastImageCache/FICEntity.h
@@ -24,7 +24,7 @@ typedef void (^FICEntityImageDrawingBlock)(CGContextRef context, CGSize contextS
  @discussion Within each image table, each entry is identified by an entity's UUID. Ideally, this value should never change for an entity. For example, if your entity class is a person
  model, its UUID might be an API-assigned, unchanging, unique user ID. No matter how the properties of the person change, its user ID should never change.
  */
-@property (nonatomic, copy, readonly) NSString *UUID;
+@property (nonatomic, copy, readonly) NSString *FIC_UUID;
 
 /**
  A string that uniquely identifies an entity's source image.
@@ -32,7 +32,7 @@ typedef void (^FICEntityImageDrawingBlock)(CGContextRef context, CGSize contextS
  @discussion While `<UUID>` should be unchanging, a source image UUID might change. For example, if your entity class is a person model, its source image UUID might change every time the
  person changes their profile photo. In this case, the source image UUID might be a hash of the profile photo URL (assuming each image is given a unique URL).
  */
-@property (nonatomic, copy, readonly) NSString *sourceImageUUID;
+@property (nonatomic, copy, readonly) NSString *FIC_sourceImageUUID;
 
 /**
  Returns the source image URL associated with a specific format name.
@@ -52,7 +52,7 @@ typedef void (^FICEntityImageDrawingBlock)(CGContextRef context, CGSize contextS
  @see FICImageFormat
  @see [FICImageCacheDelegate imageCache:wantsSourceImageForEntity:withFormatName:completionBlock:]
  */
-- (NSURL *)sourceImageURLWithFormatName:(NSString *)formatName;
+- (NSURL *)FIC_sourceImageURLWithFormatName:(NSString *)formatName;
 
 /**
  Returns the drawing block for a specific image and format name.
@@ -73,7 +73,7 @@ typedef void (^FICEntityImageDrawingBlock)(CGContextRef context, CGSize contextS
  
  @note This block will always be called from the serial dispatch queue used by the image cache.
  */
-- (FICEntityImageDrawingBlock)drawingBlockForImage:(UIImage *)image withFormatName:(NSString *)formatName;
+- (FICEntityImageDrawingBlock)FIC_drawingBlockForImage:(UIImage *)image withFormatName:(NSString *)formatName;
 
 @optional
 /**
@@ -81,6 +81,6 @@ typedef void (^FICEntityImageDrawingBlock)(CGContextRef context, CGSize contextS
  
  @param format The image format that identifies which image table is requesting the source image.
  */
-- (UIImage *)imageForFormat:(FICImageFormat *)format;
+- (UIImage *)FIC_imageForFormat:(FICImageFormat *)format;
 
 @end

--- a/FastImageCache/FastImageCache/FastImageCache/FICImageCache.m
+++ b/FastImageCache/FastImageCache/FastImageCache/FICImageCache.m
@@ -163,8 +163,8 @@ static NSString *const FICImageCacheEntityKey = @"FICImageCacheEntityKey";
     BOOL imageExists = NO;
     
     FICImageTable *imageTable = [_imageTables objectForKey:formatName];
-    NSString *entityUUID = [entity UUID];
-    NSString *sourceImageUUID = [entity sourceImageUUID];
+    NSString *entityUUID = [entity FIC_UUID];
+    NSString *sourceImageUUID = [entity FIC_sourceImageUUID];
     
     if (loadSynchronously == NO && [imageTable entryExistsForEntityUUID:entityUUID sourceImageUUID:sourceImageUUID]) {
         imageExists = YES;
@@ -196,7 +196,7 @@ static NSString *const FICImageCacheEntityKey = @"FICImageCacheEntityKey";
         
         if (image == nil) {
             // No image for this UUID exists in the image table. We'll need to ask the delegate to retrieve the source asset.
-            NSURL *sourceImageURL = [entity sourceImageURLWithFormatName:formatName];
+            NSURL *sourceImageURL = [entity FIC_sourceImageURLWithFormatName:formatName];
             
             if (sourceImageURL != nil) {
                 // We check to see if this image is already being fetched.
@@ -216,9 +216,9 @@ static NSString *const FICImageCacheEntityKey = @"FICImageCacheEntityKey";
                 if (needsToFetch) {
                     @autoreleasepool {
                         UIImage *image;
-                        if ([entity respondsToSelector:@selector(imageForFormat:)]){
+                        if ([entity respondsToSelector:@selector(FIC_imageForFormat:)]){
                             FICImageFormat *format = [self formatWithName:formatName];
-                            image = [entity imageForFormat:format];
+                            image = [entity FIC_imageForFormat:format];
                         }
                         
                         if (image){
@@ -274,7 +274,7 @@ static NSString *const FICImageCacheEntityKey = @"FICImageCacheEntityKey";
 }
 
 static void _FICAddCompletionBlockForEntity(NSString *formatName, NSMutableDictionary *entityRequestsDictionary, id <FICEntity> entity, FICImageCacheCompletionBlock completionBlock) {
-    NSString *entityUUID = [entity UUID];
+    NSString *entityUUID = [entity FIC_UUID];
     NSMutableDictionary *requestDictionary = [entityRequestsDictionary objectForKey:entityUUID];
     NSMutableDictionary *completionBlocks = nil;
     
@@ -315,7 +315,7 @@ static void _FICAddCompletionBlockForEntity(NSString *formatName, NSMutableDicti
             completionBlocksDictionary = [NSDictionary dictionaryWithObject:[NSArray arrayWithObject:[completionBlock copy]] forKey:formatName];
         }
         
-        NSString *entityUUID = [entity UUID];
+        NSString *entityUUID = [entity FIC_UUID];
         FICImageTable *imageTable = [_imageTables objectForKey:formatName];
         if (imageTable) {
             [imageTable deleteEntryForEntityUUID:entityUUID];
@@ -338,21 +338,21 @@ static void _FICAddCompletionBlockForEntity(NSString *formatName, NSMutableDicti
 
 - (void)_processImage:(UIImage *)image forEntity:(id <FICEntity>)entity imageTable:(FICImageTable *)imageTable completionBlocks:(NSArray *)completionBlocks {
     if (imageTable != nil) {
-        if ([entity UUID] == nil) {
+        if ([entity FIC_UUID] == nil) {
             [self _logMessage:[NSString stringWithFormat:@"*** FIC Error: %s entity %@ is missing its UUID.", __PRETTY_FUNCTION__, entity]];
             return;
         }
         
-        if ([entity sourceImageUUID] == nil) {
+        if ([entity FIC_sourceImageUUID] == nil) {
             [self _logMessage:[NSString stringWithFormat:@"*** FIC Error: %s entity %@ is missing its source image UUID.", __PRETTY_FUNCTION__, entity]];
             return;
         }
         
-        NSString *entityUUID = [entity UUID];
-        NSString *sourceImageUUID = [entity sourceImageUUID];
+        NSString *entityUUID = [entity FIC_UUID];
+        NSString *sourceImageUUID = [entity FIC_sourceImageUUID];
         FICImageFormat *imageFormat = [imageTable imageFormat];
         NSString *imageFormatName = [imageFormat name];
-        FICEntityImageDrawingBlock imageDrawingBlock = [entity drawingBlockForImage:image withFormatName:imageFormatName];
+        FICEntityImageDrawingBlock imageDrawingBlock = [entity FIC_drawingBlockForImage:image withFormatName:imageFormatName];
         
         dispatch_async([FICImageCache dispatchQueue], ^{
             [imageTable setEntryForEntityUUID:entityUUID sourceImageUUID:sourceImageUUID imageDrawingBlock:imageDrawingBlock];
@@ -412,7 +412,7 @@ static void _FICAddCompletionBlockForEntity(NSString *formatName, NSMutableDicti
             }
 
             // If the image already exists, keep going
-            if ([table entryExistsForEntityUUID:entity.UUID sourceImageUUID:entity.sourceImageUUID]) {
+            if ([table entryExistsForEntityUUID:entity.FIC_UUID sourceImageUUID:entity.FIC_sourceImageUUID]) {
                 continue;
             }
 
@@ -427,8 +427,8 @@ static void _FICAddCompletionBlockForEntity(NSString *formatName, NSMutableDicti
 
 - (BOOL)imageExistsForEntity:(id <FICEntity>)entity withFormatName:(NSString *)formatName {
     FICImageTable *imageTable = [_imageTables objectForKey:formatName];
-    NSString *entityUUID = [entity UUID];
-    NSString *sourceImageUUID = [entity sourceImageUUID];
+    NSString *entityUUID = [entity FIC_UUID];
+    NSString *sourceImageUUID = [entity FIC_sourceImageUUID];
     
     BOOL imageExists = [imageTable entryExistsForEntityUUID:entityUUID sourceImageUUID:sourceImageUUID];
 
@@ -439,13 +439,13 @@ static void _FICAddCompletionBlockForEntity(NSString *formatName, NSMutableDicti
 
 - (void)deleteImageForEntity:(id <FICEntity>)entity withFormatName:(NSString *)formatName {
     FICImageTable *imageTable = [_imageTables objectForKey:formatName];
-    NSString *entityUUID = [entity UUID];    
+    NSString *entityUUID = [entity FIC_UUID];
     [imageTable deleteEntryForEntityUUID:entityUUID];
 }
 
 - (void)cancelImageRetrievalForEntity:(id <FICEntity>)entity withFormatName:(NSString *)formatName {
-    NSURL *sourceImageURL = [entity sourceImageURLWithFormatName:formatName];
-    NSString *entityUUID = [entity UUID];
+    NSURL *sourceImageURL = [entity FIC_sourceImageURLWithFormatName:formatName];
+    NSString *entityUUID = [entity FIC_UUID];
 
     BOOL cancelImageLoadingForEntity = NO;
     @synchronized (_requests) {

--- a/FastImageCache/FastImageCache/FastImageCache/FICImageCache.m
+++ b/FastImageCache/FastImageCache/FastImageCache/FICImageCache.m
@@ -163,8 +163,8 @@ static NSString *const FICImageCacheEntityKey = @"FICImageCacheEntityKey";
     BOOL imageExists = NO;
     
     FICImageTable *imageTable = [_imageTables objectForKey:formatName];
-    NSString *entityUUID = [entity FIC_UUID];
-    NSString *sourceImageUUID = [entity FIC_sourceImageUUID];
+    NSString *entityUUID = [entity fic_UUID];
+    NSString *sourceImageUUID = [entity fic_sourceImageUUID];
     
     if (loadSynchronously == NO && [imageTable entryExistsForEntityUUID:entityUUID sourceImageUUID:sourceImageUUID]) {
         imageExists = YES;
@@ -196,7 +196,7 @@ static NSString *const FICImageCacheEntityKey = @"FICImageCacheEntityKey";
         
         if (image == nil) {
             // No image for this UUID exists in the image table. We'll need to ask the delegate to retrieve the source asset.
-            NSURL *sourceImageURL = [entity FIC_sourceImageURLWithFormatName:formatName];
+            NSURL *sourceImageURL = [entity fic_sourceImageURLWithFormatName:formatName];
             
             if (sourceImageURL != nil) {
                 // We check to see if this image is already being fetched.
@@ -216,9 +216,9 @@ static NSString *const FICImageCacheEntityKey = @"FICImageCacheEntityKey";
                 if (needsToFetch) {
                     @autoreleasepool {
                         UIImage *image;
-                        if ([entity respondsToSelector:@selector(FIC_imageForFormat:)]){
+                        if ([entity respondsToSelector:@selector(fic_imageForFormat:)]){
                             FICImageFormat *format = [self formatWithName:formatName];
-                            image = [entity FIC_imageForFormat:format];
+                            image = [entity fic_imageForFormat:format];
                         }
                         
                         if (image){
@@ -274,7 +274,7 @@ static NSString *const FICImageCacheEntityKey = @"FICImageCacheEntityKey";
 }
 
 static void _FICAddCompletionBlockForEntity(NSString *formatName, NSMutableDictionary *entityRequestsDictionary, id <FICEntity> entity, FICImageCacheCompletionBlock completionBlock) {
-    NSString *entityUUID = [entity FIC_UUID];
+    NSString *entityUUID = [entity fic_UUID];
     NSMutableDictionary *requestDictionary = [entityRequestsDictionary objectForKey:entityUUID];
     NSMutableDictionary *completionBlocks = nil;
     
@@ -315,7 +315,7 @@ static void _FICAddCompletionBlockForEntity(NSString *formatName, NSMutableDicti
             completionBlocksDictionary = [NSDictionary dictionaryWithObject:[NSArray arrayWithObject:[completionBlock copy]] forKey:formatName];
         }
         
-        NSString *entityUUID = [entity FIC_UUID];
+        NSString *entityUUID = [entity fic_UUID];
         FICImageTable *imageTable = [_imageTables objectForKey:formatName];
         if (imageTable) {
             [imageTable deleteEntryForEntityUUID:entityUUID];
@@ -338,21 +338,21 @@ static void _FICAddCompletionBlockForEntity(NSString *formatName, NSMutableDicti
 
 - (void)_processImage:(UIImage *)image forEntity:(id <FICEntity>)entity imageTable:(FICImageTable *)imageTable completionBlocks:(NSArray *)completionBlocks {
     if (imageTable != nil) {
-        if ([entity FIC_UUID] == nil) {
+        if ([entity fic_UUID] == nil) {
             [self _logMessage:[NSString stringWithFormat:@"*** FIC Error: %s entity %@ is missing its UUID.", __PRETTY_FUNCTION__, entity]];
             return;
         }
         
-        if ([entity FIC_sourceImageUUID] == nil) {
+        if ([entity fic_sourceImageUUID] == nil) {
             [self _logMessage:[NSString stringWithFormat:@"*** FIC Error: %s entity %@ is missing its source image UUID.", __PRETTY_FUNCTION__, entity]];
             return;
         }
         
-        NSString *entityUUID = [entity FIC_UUID];
-        NSString *sourceImageUUID = [entity FIC_sourceImageUUID];
+        NSString *entityUUID = [entity fic_UUID];
+        NSString *sourceImageUUID = [entity fic_sourceImageUUID];
         FICImageFormat *imageFormat = [imageTable imageFormat];
         NSString *imageFormatName = [imageFormat name];
-        FICEntityImageDrawingBlock imageDrawingBlock = [entity FIC_drawingBlockForImage:image withFormatName:imageFormatName];
+        FICEntityImageDrawingBlock imageDrawingBlock = [entity fic_drawingBlockForImage:image withFormatName:imageFormatName];
         
         dispatch_async([FICImageCache dispatchQueue], ^{
             [imageTable setEntryForEntityUUID:entityUUID sourceImageUUID:sourceImageUUID imageDrawingBlock:imageDrawingBlock];
@@ -412,7 +412,7 @@ static void _FICAddCompletionBlockForEntity(NSString *formatName, NSMutableDicti
             }
 
             // If the image already exists, keep going
-            if ([table entryExistsForEntityUUID:entity.FIC_UUID sourceImageUUID:entity.FIC_sourceImageUUID]) {
+            if ([table entryExistsForEntityUUID:entity.fic_UUID sourceImageUUID:entity.fic_sourceImageUUID]) {
                 continue;
             }
 
@@ -427,8 +427,8 @@ static void _FICAddCompletionBlockForEntity(NSString *formatName, NSMutableDicti
 
 - (BOOL)imageExistsForEntity:(id <FICEntity>)entity withFormatName:(NSString *)formatName {
     FICImageTable *imageTable = [_imageTables objectForKey:formatName];
-    NSString *entityUUID = [entity FIC_UUID];
-    NSString *sourceImageUUID = [entity FIC_sourceImageUUID];
+    NSString *entityUUID = [entity fic_UUID];
+    NSString *sourceImageUUID = [entity fic_sourceImageUUID];
     
     BOOL imageExists = [imageTable entryExistsForEntityUUID:entityUUID sourceImageUUID:sourceImageUUID];
 
@@ -439,13 +439,13 @@ static void _FICAddCompletionBlockForEntity(NSString *formatName, NSMutableDicti
 
 - (void)deleteImageForEntity:(id <FICEntity>)entity withFormatName:(NSString *)formatName {
     FICImageTable *imageTable = [_imageTables objectForKey:formatName];
-    NSString *entityUUID = [entity FIC_UUID];
+    NSString *entityUUID = [entity fic_UUID];
     [imageTable deleteEntryForEntityUUID:entityUUID];
 }
 
 - (void)cancelImageRetrievalForEntity:(id <FICEntity>)entity withFormatName:(NSString *)formatName {
-    NSURL *sourceImageURL = [entity FIC_sourceImageURLWithFormatName:formatName];
-    NSString *entityUUID = [entity FIC_UUID];
+    NSURL *sourceImageURL = [entity fic_sourceImageURLWithFormatName:formatName];
+    NSString *entityUUID = [entity fic_UUID];
 
     BOOL cancelImageLoadingForEntity = NO;
     @synchronized (_requests) {

--- a/FastImageCache/FastImageCacheDemo/Classes/FICDPhoto.m
+++ b/FastImageCache/FastImageCacheDemo/Classes/FICDPhoto.m
@@ -167,7 +167,7 @@ static UIImage * _FICDStatusBarImageFromImage(UIImage *image) {
 
 #pragma mark - FICImageCacheEntity
 
-- (NSString *)FIC_UUID {
+- (NSString *)fic_UUID {
     if (_UUID == nil) {
         // MD5 hashing is expensive enough that we only want to do it once
         NSString *imageName = [_sourceImageURL lastPathComponent];
@@ -178,15 +178,15 @@ static UIImage * _FICDStatusBarImageFromImage(UIImage *image) {
     return _UUID;
 }
 
-- (NSString *)FIC_sourceImageUUID {
-    return [self FIC_UUID];
+- (NSString *)fic_sourceImageUUID {
+    return [self fic_UUID];
 }
 
-- (NSURL *)FIC_sourceImageURLWithFormatName:(NSString *)formatName {
+- (NSURL *)fic_sourceImageURLWithFormatName:(NSString *)formatName {
     return _sourceImageURL;
 }
 
-- (FICEntityImageDrawingBlock)FIC_drawingBlockForImage:(UIImage *)image withFormatName:(NSString *)formatName {
+- (FICEntityImageDrawingBlock)fic_drawingBlockForImage:(UIImage *)image withFormatName:(NSString *)formatName {
     FICEntityImageDrawingBlock drawingBlock = ^(CGContextRef contextRef, CGSize contextSize) {
         CGRect contextBounds = CGRectZero;
         contextBounds.size = contextSize;

--- a/FastImageCache/FastImageCacheDemo/Classes/FICDPhoto.m
+++ b/FastImageCache/FastImageCacheDemo/Classes/FICDPhoto.m
@@ -167,7 +167,7 @@ static UIImage * _FICDStatusBarImageFromImage(UIImage *image) {
 
 #pragma mark - FICImageCacheEntity
 
-- (NSString *)UUID {
+- (NSString *)FIC_UUID {
     if (_UUID == nil) {
         // MD5 hashing is expensive enough that we only want to do it once
         NSString *imageName = [_sourceImageURL lastPathComponent];
@@ -178,15 +178,15 @@ static UIImage * _FICDStatusBarImageFromImage(UIImage *image) {
     return _UUID;
 }
 
-- (NSString *)sourceImageUUID {
-    return [self UUID];
+- (NSString *)FIC_sourceImageUUID {
+    return [self FIC_UUID];
 }
 
-- (NSURL *)sourceImageURLWithFormatName:(NSString *)formatName {
+- (NSURL *)FIC_sourceImageURLWithFormatName:(NSString *)formatName {
     return _sourceImageURL;
 }
 
-- (FICEntityImageDrawingBlock)drawingBlockForImage:(UIImage *)image withFormatName:(NSString *)formatName {
+- (FICEntityImageDrawingBlock)FIC_drawingBlockForImage:(UIImage *)image withFormatName:(NSString *)formatName {
     FICEntityImageDrawingBlock drawingBlock = ^(CGContextRef contextRef, CGSize contextSize) {
         CGRect contextBounds = CGRectZero;
         contextBounds.size = contextSize;


### PR DESCRIPTION
- Add prefix `fic` to all the property and method in protocol `FICEntity` to avoid property and method conflict with other library. 
- See issue : [Property `UUID` duplicate(conflict) with other Library :(](https://github.com/path/FastImageCache/issues/137)