### PR TITLE
Adding protection mode while writing content to the file

### DIFF
--- a/FastImageCache.podspec
+++ b/FastImageCache.podspec
@@ -1,0 +1,24 @@
+
+Pod::Spec.new do |s|
+
+  s.name         = "FastImageCache"
+  s.version      = "1.5.1"
+  s.summary      = "iOS library for quickly displaying images while scrolling"
+
+  s.description  = <<-DESC
+Fast Image Cache is an efficient, persistent, and—above all—fast way to store and retrieve images in your iOS application. Part of any good iOS application's user experience is fast, smooth scrolling, and Fast Image Cache helps make this easier.
+A significant burden on performance for graphics-rich applications like Path is image loading. The traditional method of loading individual images from disk is just too slow, especially while scrolling. Fast Image Cache was created specifically to solve this problem.
+                   DESC
+
+  s.homepage     = "https://github.com/gauravmnit07/FastImageCache"
+  s.license      = { :type => 'MIT', :file => 'LICENSE' }
+  s.authors      = { "Mallory Paine" => "mallory@path.com", "Michael Potter" => "michael@path.com" }
+
+  s.platform     = :ios
+  s.platform     = :ios, '6.0'
+  s.source       = { :git => "https://github.com/gauravmnit07/FastImageCache.git" }
+
+  s.source_files  = "FastImageCache/FastImageCache/**/*.{h,m}"
+  s.requires_arc = true
+
+end

--- a/FastImageCache/FastImageCache/FastImageCache/FICImageFormat.h
+++ b/FastImageCache/FastImageCache/FastImageCache/FICImageFormat.h
@@ -147,6 +147,8 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nonatomic, assign, readonly) NSString *protectionModeString;
 
+@property (nonatomic, assign, readonly) NSDataWritingOptions protectionModeOption;
+
 /**
  The dictionary representation of this image format.
  

--- a/FastImageCache/FastImageCache/FastImageCache/FICImageFormat.m
+++ b/FastImageCache/FastImageCache/FastImageCache/FICImageFormat.m
@@ -143,6 +143,22 @@ static NSString *const FICImageFormatProtectionModeKey = @"protectionMode";
     return protectionModeString;
 }
 
+- (NSDataWritingOptions)protectionModeOption {
+    NSDataWritingOptions protectionModeOption = NSDataWritingFileProtectionNone;
+    switch (_protectionMode) {
+        case FICImageFormatProtectionModeNone:
+            protectionModeOption = NSDataWritingFileProtectionNone;
+            break;
+        case FICImageFormatProtectionModeComplete:
+            protectionModeOption = NSDataWritingFileProtectionComplete;
+            break;
+        case FICImageFormatProtectionModeCompleteUntilFirstUserAuthentication:
+            protectionModeOption = NSDataWritingFileProtectionCompleteUntilFirstUserAuthentication;
+            break;
+    }
+    return protectionModeOption;
+}
+
 #pragma mark - Object Lifecycle
 
 + (instancetype)formatWithName:(NSString *)name family:(NSString *)family imageSize:(CGSize)imageSize style:(FICImageFormatStyle)style maximumCount:(NSInteger)maximumCount devices:(FICImageFormatDevices)devices protectionMode:(FICImageFormatProtectionMode)protectionMode {

--- a/FastImageCache/FastImageCache/FastImageCache/FICImageTable.m
+++ b/FastImageCache/FastImageCache/FastImageCache/FICImageTable.m
@@ -714,7 +714,7 @@ static void _FICReleaseImageData(void *info, const void *data, size_t size) {
                     return;
                 }
 
-                BOOL fileWriteResult = [data writeToFile:[self metadataFilePath] atomically:NO];
+                BOOL fileWriteResult = [data writeToFile:[self metadataFilePath] options:[_imageFormat protectionModeOption] error:nil];
                 if (fileWriteResult == NO) {
                     NSString *message = [NSString stringWithFormat:@"*** FIC Error: %s couldn't write metadata for format %@", __PRETTY_FUNCTION__, [_imageFormat name]];
                     [self.imageCache _logMessage:message];


### PR DESCRIPTION
Security scan tools are complaining that we should apply appropriate protection mode everytime when we are writing content to the file.